### PR TITLE
Adding subscription support

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,12 @@
 {
-    "core": "WordPress/WordPress#master",
+    "core": "WordPress/WordPress#6.7.1",
     "plugins": [
-        "../woocommerce/plugins/woocommerce",
+        "../woocommerce",
+        "../woocommerce-subscriptions",
+        "../woo-stripe-payment",
         "."
-    ]
+    ],
+    "config": {
+        "WP_DEBUG_LOG": "/var/www/html/wp-content/debug.log"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ This section outlines the steps to install the HealthKey plugin.
 13. Tick Enable HealthKey.
 14. Save changes.
 
+## End User Instructions
+
+- We expect the interval of a subscription product with the same product id not to change. If you want to change the subscription interval of an existing product reach out to HealthKey to make this change.
+
 ## Plugin Development
 
 1. Run `npm install`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ This section outlines the steps to install the HealthKey plugin.
 
 ## End User Instructions
 
+### Subscriptions
+
 - We expect the interval of a subscription product with the same product id not to change. If you want to change the subscription interval of an existing product reach out to HealthKey to make this change.
+- We will charge shipping on the initial order but do not currently support charging shipping for subscriptions
 
 ## Plugin Development
 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -653,6 +653,11 @@ function disable_hk_payment_for_unsupported_subscriptions( $available_gateways )
             $supported_cart = False;
         }
 
+        $subscription_length = WC_Subscriptions_Product::get_length($product);
+        if($subscription_length != 0) {
+            $supported_cart = False;
+        }
+
        }
     }
 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -251,7 +251,7 @@ function requestPayment($access_token, $order)
         if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $product )  ) {
             $subscription_period = WC_Subscriptions_Product::get_period($product);
             $subscription_interval = WC_Subscriptions_Product::get_interval($product);
-            $subscription_length = WC_Subscriptions_Product::get_length($product);
+            // $subscription_length = WC_Subscriptions_Product::get_length($product); // We don't currently support subscriptions of a pre-determined length
             $frequency = map_subscription_period_and_interval_to_hk($subscription_period, $subscription_interval);
             // print_r($frequency);
             $starting_date = date("Y-m-d");
@@ -637,6 +637,11 @@ function disable_hk_payment_for_unsupported_subscriptions( $available_gateways )
        if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $product )  ) {
         $subscripton_product_count += 1;
         if($cart_item['quantity'] != 1) {
+            $supported_cart = False;
+        }
+
+        $subscription_length = WC_Subscriptions_Product::get_length($product);
+        if($subscription_length != 0) {
             $supported_cart = False;
         }
        }

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -158,13 +158,28 @@ add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', 'handle_hk_tran
  * @return wp_redirect
  */
 function processSubscriptionTermination(WP_REST_Request $request) {
-    $transaction_id = $request[''];
+    $transaction_id = $request['transactionId'];
+    $product_id = $request['productExternalId'];
+
+    print_r($transaction_id);
     $args = array(
-        'hk_transaction_id' => 'HK-21',
+        'meta_key' => 'hk_transaction_id',
+        'meta_value' => $transaction_id,
+        'meta_compare'  => '='
     );
     $orders = wc_get_orders( $args );
-    print_r($orders);
-    // WC_Subscriptions_Manager::process_subscription_payment_failure_on_order()
+
+    if(count($orders) < 1) {
+        return new WP_Error( 'no_order_found_for_transaction_id', 'No order was found with transaction id', array( 'status' => 404 ) );
+    }
+
+    if(count($orders) > 1) {
+        return new WP_Error( 'multiple_orders_found_for_transaction_id', 'Multiple orders were found with transaction id', array( 'status' => 500 ) );
+    }
+
+
+    WC_Subscriptions_Manager::process_subscription_payment_failure_on_order($orders[0], $product_id);
+    return new WP_REST_Response(null, 200); ;
 }
 
 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -323,6 +323,10 @@ function map_subscription_period_and_interval_to_hk($woo_commerce_subscription_p
     }
 }
 
+function map_trial_to_hk() {
+
+}
+
 /**
  * intitialise Woocommerce integration
  * 
@@ -645,7 +649,11 @@ function disable_hk_payment_for_unsupported_subscriptions( $available_gateways )
             $supported_cart = False;
         }
 
-        $subscription_length = WC_Subscriptions_Product::get_length($product);
+        $has_trial_period   = WC_Subscriptions_Product::get_trial_length( $product ) > 0;
+        if($has_trial_period) {
+            $supported_cart = False;
+        }
+
        }
     }
 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -423,7 +423,7 @@ function healthkey_payment_init()
              */
             public function __construct()
             {
-                $this->supports =  array( 'subscriptions', 'products', 'gateway_scheduled_payments'); //TODO: Add features we support here
+                $this->supports =  array( 'subscriptions', 'products', 'gateway_scheduled_payments');
                 $this->id   = 'healthkey_payment';
                 $this->icon = apply_filters('woocommerce_healthkey_icon', plugins_url('/assets/icon.png', __FILE__ ));
                 $this->has_fields = false;

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -321,10 +321,6 @@ function map_subscription_period_and_interval_to_hk($woo_commerce_subscription_p
     }
 }
 
-function map_trial_to_hk() {
-
-}
-
 /**
  * intitialise Woocommerce integration
  * 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -114,6 +114,11 @@ function processTransaction(WP_REST_Request $request)
     $order = wc_get_order( $_SESSION['hk_order_id'] );
 
     $payment_response = requestPayment($access_token, $order);
+
+    if(is_null($payment_response) || !isset($payment_response->status) || !is_string( $payment_response->status) || !is_string($payment_response->id)) {
+        wp_redirect( wc_get_checkout_url() );
+        exit();
+    }
     
     $transaction_status = $payment_response->status;
     $transaction_id = $payment_response->id;

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -646,9 +646,6 @@ function disable_hk_payment_for_unsupported_subscriptions( $available_gateways )
         }
 
         $subscription_length = WC_Subscriptions_Product::get_length($product);
-        if($subscription_length != 0) {
-            $supported_cart = False;
-        }
        }
     }
 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -658,6 +658,11 @@ function disable_hk_payment_for_unsupported_subscriptions( $available_gateways )
             $supported_cart = False;
         }
 
+        $sign_up_fee_due  = WC_Subscriptions_Product::get_sign_up_fee( $product );
+        if($sign_up_fee_due != 0) {
+            $supported_cart = False;
+        }
+
        }
     }
 

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -236,8 +236,9 @@ function requestPayment($access_token, $order)
         $externalId = NULL;
         $variationId = $item->get_variation_id();
         $productId = $item->get_product_id();
+
     
-        if ((is_string($variationId) && strlen($variationId) > 0) || is_numeric($variationId)) {
+        if ((is_string($variationId) && strlen($variationId) > 0) || (is_numeric($variationId) && $variationId > 0)) {
             $externalId = $variationId;
         } else {
             $externalId = $productId;
@@ -279,8 +280,6 @@ function requestPayment($access_token, $order)
             "quantity"      => 1,
         ];
     }
-
-    // print_r($products);
 
     $successUrl = $order->get_checkout_order_received_url();
 
@@ -429,7 +428,7 @@ function healthkey_payment_init()
              */
             public function __construct()
             {
-                $this->supports =  array( 'subscriptions', 'gateway_scheduled_payments'); //TODO: Add features we support here
+                $this->supports =  array( 'subscriptions', 'products', 'gateway_scheduled_payments'); //TODO: Add features we support here
                 $this->id   = 'healthkey_payment';
                 $this->icon = apply_filters('woocommerce_healthkey_icon', plugins_url('/assets/icon.png', __FILE__ ));
                 $this->has_fields = false;

--- a/healthkey-payments-for-woocomerce.php
+++ b/healthkey-payments-for-woocomerce.php
@@ -259,7 +259,6 @@ function requestPayment($access_token, $order)
             $subscription_interval = WC_Subscriptions_Product::get_interval($product);
             // $subscription_length = WC_Subscriptions_Product::get_length($product); // We don't currently support subscriptions of a pre-determined length
             $frequency = map_subscription_period_and_interval_to_hk($subscription_period, $subscription_interval);
-            // print_r($frequency);
             $starting_date = date("Y-m-d");
             $productIndex = count($products) - 1;
             $products[$productIndex]["subscription"] = [


### PR DESCRIPTION
TODO
- [x] Ensure plugin works with shipping (Floe's FAQ claims free shipping for subscriptions, the initial shipping is charged as a one off but we don't support recurring shipping charges)
- [x] See if it is quick to support multiple quantities of same subscription (We don't currently have a concept of a subscription with a quantity so will leave for now)
- [x] Update the 'supports' info to be accurate
- [x] Ensure we don't let the user change the payment method on the provider side
- [x] Ensure we support without WooCommerce Subscriptions plugin
- [ ] Support subscription length
- [x] Execute testing plan https://www.notion.so/healthkey/WooCommerce-Subscriptions-Testing-Plan-1bc30c964228802c9fe4d65d2e8c73eb







